### PR TITLE
Make commands run separately in pane.

### DIFF
--- a/itermocil.py
+++ b/itermocil.py
@@ -445,16 +445,15 @@ class Itermocil(object):
         if name:
             name_command = 'set name to "' + name + '"'
 
-        # Turn commands list into a string command
-        command = "; ".join(commands)
-
-        # Build the applescript snippet.
-        self.applescript.append(
-            ''' tell {tell_target}
-                    write text "{command}"
-                    {name}
-                end tell
-            '''.format(tell_target=tell_target, command=command, name=name_command))
+        # Run each command separately
+        for command in commands:
+            # Build the applescript snippet.
+            self.applescript.append(
+                ''' tell {tell_target}
+                        write text "{command}"
+                        {name}
+                    end tell
+                '''.format(tell_target=tell_target, command=command, name=name_command))
 
     def initiate_window(self, commands=None):
         """ Runs the list of commands in the current pane


### PR DESCRIPTION
Currently, commands are run by joining together by `;`. Because multiple commands
are joined into one single command, it raises the problem when we want
to reuse only one command in history, or search in history. History
always show that command in one single line with other commands.